### PR TITLE
preprare for 1.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-### Fixed
-
-- Improved documentation on `new()`
+## [v1.0.1]
 
 ### Added
 
+- Explicit use of wrapping add for `cnt` counter
 - Asserts to check the `reload` value
 - CI changelog entry enforcer
 
@@ -29,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Initial release
 
-[Unreleased]: https://github.com/rtic-rs/systick-monotonic/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/rtic-rs/systick-monotonic/compare/v1.0.1...HEAD
+[v1.0.1]: https://github.com/rtic-rs/systick-monotonic/compare/v1.0.0...v1.0.1
 [v1.0.0]: https://github.com/rtic-rs/systick-monotonic/compare/v0.1.0...v1.0.0
 [v0.1.0]: https://github.com/rtic-rs/systick-monotonic/compare/2220d9b...v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "systick-monotonic"
-version = "1.0.0"
+version = "1.0.1"
 authors = [
   "The Real-Time Interrupt-driven Concurrency developers",
   "Emil Fresk <emil.fresk@gmail.com>",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,7 @@ impl<const TIMER_HZ: u32> Monotonic for Systick<TIMER_HZ> {
         Self::Instant::from_ticks(0)
     }
 
+    #[inline(always)]
     fn on_interrupt(&mut self) {
         if self.systick.has_wrapped() {
             self.cnt = self.cnt.wrapping_add(1);


### PR DESCRIPTION
Small fixes:

- Explicit use of wrapping add for `cnt` counter
- Refactor to use `on_interrupt` as single place timer update
- Asserts to check the `reload` value
- CI changelog entry enforcer